### PR TITLE
Add check and spoken error if requested update while offline

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,6 +32,7 @@ from neon_utils.validator_utils import numeric_confirmation_validator
 from ovos_utils import classproperty
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import RuntimeRequirements
+from ovos_utils.network_utils import is_connected_http
 from neon_utils.skills import NeonSkill
 from neon_utils.user_utils import get_user_prefs
 from mycroft.skills import intent_file_handler, intent_handler
@@ -138,6 +139,12 @@ class UpdateSkill(NeonSkill):
         self._check_latest_core_release(message)
         if not all((self.current_ver, self.latest_ver)):
             self.speak_dialog("check_error")
+            return
+
+        # TODO: Support alternate update sources?
+        if not is_connected_http("https://github.com"):
+            LOG.warning(f"GitHub not available. Skipping update")
+            self.speak_dialog("error_offline")
             return
 
         if self.current_ver == self.latest_ver:

--- a/locale/en-us/dialog/error_offline.dialog
+++ b/locale/en-us/dialog/error_offline.dialog
@@ -1,0 +1,1 @@
+Sorry, I can't start an update without a connection to git hub dot com.

--- a/test/test_resources.yaml
+++ b/test/test_resources.yaml
@@ -45,6 +45,7 @@ dialog:
   - "confirm_change_update_track"
   - "confirm_no_change_update_track"
   - "core_version"
+  - "error_offline"
 # regex entities, not necessarily filenames
 regex: []
 intents:

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -140,6 +140,8 @@ class TestSkill(unittest.TestCase):
         self.assertEqual(start_update.call_args[0][0].data,
                          {"version": new_ver})
 
+        # TODO: Test offline
+
         self.skill.ask_yesno = real_ask_yesno
 
     def test_handle_switch_update_track(self):


### PR DESCRIPTION
# Description
Check that GitHub is accessible before starting an update to prevent unexpected errors during the update process

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->