### PR TITLE
Handle more descriptive error responses from reset plugin

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -534,8 +534,11 @@ class UpdateSkill(NeonSkill):
                                                       **{"notification": text}})
 
         else:
-            LOG.info("Showing Write Failed Notification")
-            text = self.translate("notify_installation_failed")
+            error = message.data.get("error") or "error_unknown"
+            # `no_valid_device`, `no_image_file`, something else
+            LOG.info(f"Showing Write Failed Notification: {error}")
+            text = self.translate("notify_installation_failed",
+                                  {"error": self.translate(error)})
             self.gui.show_notification(content=text,
                                        action="update.gui.finish_installation",
                                        style="error",

--- a/locale/en-us/dialog/error_unknown.dialog
+++ b/locale/en-us/dialog/error_unknown.dialog
@@ -1,0 +1,1 @@
+Unknown Error

--- a/locale/en-us/dialog/no_image_file.dialog
+++ b/locale/en-us/dialog/no_image_file.dialog
@@ -1,0 +1,1 @@
+No Image to Write

--- a/locale/en-us/dialog/no_valid_device.dialog
+++ b/locale/en-us/dialog/no_valid_device.dialog
@@ -1,0 +1,1 @@
+No Device to Write

--- a/locale/en-us/dialog/notify_installation_failed.dialog
+++ b/locale/en-us/dialog/notify_installation_failed.dialog
@@ -1,1 +1,1 @@
-OS Installation Failed
+OS Installation Failed: {{error}}

--- a/test/test_resources.yaml
+++ b/test/test_resources.yaml
@@ -58,6 +58,9 @@ dialog:
   - "help_support"
   - "update_initramfs_success"
   - "update_continuing"
+  - "error_unknown"
+  - "no_image_file"
+  - "no_valid_device"
 # regex entities, not necessarily filenames
 regex: []
 intents:


### PR DESCRIPTION
# Description
Handle error messages from reset plugin and display more descriptive notifications accordingly

# Issues
Needs https://github.com/NeonGeckoCom/neon-phal-plugin-reset/pull/32

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->