### PR TITLE
Prevent multiple update processes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -332,12 +332,16 @@ class UpdateSkill(NeonSkill):
                         else:
                             self._updating = False
                     else:
-                        error = resp.data.get("error")
+                        try:
+                            error = resp.data.get("error")
+                        except AttributeError:
+                            error = "timeout"
                         LOG.error(f"initramfs update failed: {error}")
                         self.speak_dialog("error_updating_os",
                                           {"help":
                                            self.translate("help_support")})
                         self.gui.remove_controlled_notification()
+                        self._updating = False
                         return
                 if squashfs_available:
                     self._write_update_signal("squashfs")

--- a/locale/en-us/dialog/update_in_progress.dialog
+++ b/locale/en-us/dialog/update_in_progress.dialog
@@ -1,0 +1,1 @@
+I am already working on updates.

--- a/test/test_resources.yaml
+++ b/test/test_resources.yaml
@@ -62,6 +62,7 @@ dialog:
   - "no_image_file"
   - "no_valid_device"
   - "ask_update_anyways"
+  - "update_in_progress"
 # regex entities, not necessarily filenames
 regex: []
 intents:

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -173,6 +173,11 @@ class TestSkill(unittest.TestCase):
         self.assertEqual(start_update.call_args[0][0].data,
                          {"version": new_ver})
 
+        # Update already in-progress
+        self.skill._updating = True
+        self.skill.handle_update_device(message)
+        self.skill.speak_dialog.assert_called_with("update_in_progress")
+
         # TODO: Test offline
 
         self.skill.bus.remove_all_listeners("neon.core_updater.check_update")


### PR DESCRIPTION
# Description
Add an internal flag for active update process and prevent multiple concurrent download attempts
Better error handling for update timeouts

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->