### PR TITLE
Handle longer-than-30m update downloads

### DIFF
--- a/.github/workflows/skill_tests.yml
+++ b/.github/workflows/skill_tests.yml
@@ -10,6 +10,9 @@ jobs:
     uses: neongeckocom/.github/.github/workflows/python_build_tests.yml@master
   skill_unit_tests:
     uses: neongeckocom/.github/.github/workflows/skill_tests.yml@master
+    with:
+      ovos_versions: "[]"
+      # TODO: Re-enable ovos tests after ovos-workshop 0.0.16
   skill_intent_tests:
     uses: neongeckocom/.github/.github/workflows/skill_test_intents.yml@master
     with:

--- a/__init__.py
+++ b/__init__.py
@@ -402,7 +402,7 @@ class UpdateSkill(NeonSkill):
                                    activation=True)
                     self.bus.emit(message.forward("neon.update_squashfs",
                                                   {"track": track}))
-                    while not self._download_completed.wait(1800):
+                    while not self._download_completed.wait(300):
                         download_state_resp = (
                             self.bus.wait_for_response(message.forward(
                                 "neon.device_updater.get_download_status")))

--- a/__init__.py
+++ b/__init__.py
@@ -394,7 +394,6 @@ class UpdateSkill(NeonSkill):
                                               self.current_ver)})
 
                 if squashfs_available:
-                    self._write_update_signal("squashfs")
                     self._download_completed.clear()
                     LOG.info("Updating squashfs")
                     self.add_event("neon.update_squashfs.response",
@@ -446,6 +445,7 @@ class UpdateSkill(NeonSkill):
     def _handle_download_completed(self, message):
         self._download_completed.set()
         self.gui.remove_controlled_notification()
+        self._write_update_signal("squashfs")
         if message.data.get("new_version"):
             LOG.info("squashfs updated")
             self.speak_dialog("update_restarting", wait=True)

--- a/__init__.py
+++ b/__init__.py
@@ -416,7 +416,9 @@ class UpdateSkill(NeonSkill):
                             if not self._download_completed.is_set():
                                 LOG.error(f"Download completion not handled!")
                                 self._handle_download_failure()
+                                return
                         elif not download_state_resp:
+                            # This could also be an older version of the plugin
                             LOG.error(f"No response from updater plugin")
                             self._handle_download_failure()
                             return


### PR DESCRIPTION
# Description
Add more specific error handling for update plugin failures
Add unit test coverage for SquashFS updates

# Issues
Implements https://github.com/NeonGeckoCom/neon-phal-plugin-device-updater/pull/19
Closes #91

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->